### PR TITLE
Also reject paired-path escapes written with backslashes on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Jupytext ChangeLog
 - Harden the github action ([#1569](https://github.com/jupytext/jupytext/pull/1569)). Thanks to [Peyton Murray](https://github.com/peytondmurray) for this PR!
 
 **Security**
-- Paired paths can no longer be written outside the notebook's directory tree. A `formats` entry read from notebook metadata, e.g. `../../../../etc///py` or an absolute path, is now rejected instead of driving a file write above the working tree ([#1588](https://github.com/jupytext/jupytext/pull/1588)).
+- Paired paths can no longer be written outside the notebook's directory tree. A `formats` entry read from notebook metadata, e.g. `../../../../etc///py` or an absolute path (including backslash-separated `..` or roots on Windows), is now rejected instead of driving a file write above the working tree ([#1588](https://github.com/jupytext/jupytext/pull/1588)).
 
 1.19.4 (2026-06-21)
 -------------------

--- a/src/jupytext/paired_paths.py
+++ b/src/jupytext/paired_paths.py
@@ -66,25 +66,32 @@ def separator(path):
     return "/"
 
 
-def _path_reach(path, sep):
+def _path_reach(path):
     """Describe how far a resolved path reaches outside its starting directory.
 
     Return an ``(anchor, climb)`` pair where ``anchor`` is the leading root the path
-    is tied to (empty for a path relative to the current directory, the separator for
-    an absolute path, or a Windows drive) and ``climb`` is the number of leading '..'
-    segments that survive after resolving '.' and normal segments, i.e. how many
-    levels the path escapes above that anchor.
+    is tied to (empty for a path relative to the current directory, ``'/'`` for an
+    absolute path, or a lower-cased Windows drive) and ``climb`` is the number of
+    leading '..' segments that survive after resolving '.' and normal segments, i.e.
+    how many levels the path escapes above that anchor.
     """
-    if path.startswith(sep):
-        anchor = sep
+    # On Windows both '/' and '\' separate path components, and a single path may mix
+    # them (the contents manager always uses '/'). Normalize to '/' so that a '..' or a
+    # root that is written with a backslash still counts - otherwise crafted 'formats'
+    # metadata could escape the tree on Windows by using the separator we don't split on.
+    if os.path.sep == "\\":
+        path = path.replace("\\", "/")
+
+    if path.startswith("/"):
+        anchor = "/"
     elif len(path) >= 2 and path[1] == ":":
-        anchor = path[:2]
+        anchor = path[:2].lower()
     else:
         anchor = ""
 
     climb = 0
     depth = 0
-    for part in path.split(sep):
+    for part in path.split("/"):
         if part in ("", "."):
             continue
         if part == "..":
@@ -364,10 +371,9 @@ def paired_paths(main_path, fmt, formats):
     # format whose prefix (e.g. '../../../' or an absolute path) makes a paired path
     # reach further up, or to a different root, than the notebook itself - otherwise
     # untrusted 'formats' metadata could drive writes outside the working tree.
-    sep = separator(main_path)
-    main_anchor, main_climb = _path_reach(main_path, sep)
+    main_anchor, main_climb = _path_reach(main_path)
     for alt_path in paths:
-        anchor, climb = _path_reach(alt_path, sep)
+        anchor, climb = _path_reach(alt_path)
         if anchor != main_anchor or climb > main_climb:
             raise InconsistentPath(
                 f"Paired path '{alt_path}' escapes the directory of the notebook '{main_path}'. "

--- a/tests/unit/test_paired_paths.py
+++ b/tests/unit/test_paired_paths.py
@@ -60,6 +60,23 @@ def test_paired_path_cannot_escape_notebook_tree(formats):
         paired_paths(nb_file, "notebooks///ipynb", formats)
 
 
+@pytest.mark.parametrize(
+    "formats",
+    [
+        # On Windows a backslash is also a path separator, so '..' or a root written with
+        # backslashes must not slip past the containment check (the notebook path itself
+        # uses '/', as the contents manager always does).
+        "notebooks///ipynb,..\\..\\..\\..\\tmp\\escape///py:light",
+        "notebooks///ipynb,\\tmp\\escape///py:light",
+    ],
+)
+def test_paired_path_cannot_escape_notebook_tree_windows(formats):
+    nb_file = "notebooks/nb.ipynb"
+    with mock.patch("os.path.sep", "\\"):
+        with pytest.raises(InconsistentPath, match="escapes the directory"):
+            paired_paths(nb_file, "notebooks///ipynb", formats)
+
+
 def test_base_path_in_tree_from_root():
     fmt = long_form_one_format("scripts///py")
     assert base_path("scripts/subfolder/test.py", fmt=fmt) == "//subfolder/test"


### PR DESCRIPTION
Hi @nvxbug , thanks for #1588.

I have reviewed it with Claude and it suggested that we could also harden it to reject escapes using backslashes on Windows. Can you let me know what you think ? Thanks !