### PR TITLE
fix: do not treat mermaid '%%' comments as percent cell markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Jupytext ChangeLog
 ==================
 
+1.19.6-dev
+----------
+
+**Fixed**
+- Mermaid `%%` comments inside a markdown cell are no longer mistaken for `py:percent` cell markers ([#1533](https://github.com/mwouts/jupytext/issues/1533))
+
 1.19.5 (2026-07-21)
 -------------------
 

--- a/src/jupytext/cell_reader.py
+++ b/src/jupytext/cell_reader.py
@@ -28,6 +28,8 @@ from .pep8 import pep8_lines_between_cells
 from .stringparser import StringParser
 
 _BLANK_LINE = re.compile(r"^\s*$")
+# Opening or closing line of a markdown fenced code block, e.g. '```mermaid' or '~~~'
+_CODE_FENCE = re.compile(r"^\s*(```|~~~)")
 _PY_INDENTED = re.compile(r"^\s")
 
 
@@ -752,9 +754,7 @@ class DoublePercentScriptCellReader(LightScriptCellReader):
         # content that merely contains '%%' (e.g. mermaid comments inside a markdown
         # cell) look like a cell marker on the next read (#1533).
         self.start_code_re = re.compile(rf"^\s*{re.escape(self.comment)} ?%%(%*)\s(.*)$")
-        self.alternative_start_code_re = re.compile(
-            rf"^\s*{re.escape(self.comment)} ?(%%|<codecell>|In\[[0-9 ]*\]:?)\s*$"
-        )
+        self.alternative_start_code_re = re.compile(rf"^\s*{re.escape(self.comment)} ?(%%|<codecell>|In\[[0-9 ]*\]:?)\s*$")
         self.explicit_soc = True
 
     def metadata_and_language_from_option_line(self, line):
@@ -803,12 +803,24 @@ class DoublePercentScriptCellReader(LightScriptCellReader):
 
         next_cell = len(lines)
         parser = StringParser(self.language or self.default_language)
+        in_fenced_code_block = False
         for i, line in enumerate(lines):
             if parser.is_quoted():
                 parser.read_line(line)
                 continue
 
             parser.read_line(line)
+
+            if self.cell_type in ("markdown", "raw"):
+                # Inside a markdown (or raw) cell, a fenced code block may contain
+                # anything - including '%%' comments, e.g. in mermaid diagrams (#1533).
+                # We don't look for cell markers until the block is closed.
+                if _CODE_FENCE.match(uncomment([line], self.comment, self.comment_suffix)[0]):
+                    in_fenced_code_block = not in_fenced_code_block
+                    continue
+                if in_fenced_code_block:
+                    continue
+
             if i > 0 and (self.start_code_re.match(line) or self.alternative_start_code_re.match(line)):
                 next_cell = i
                 break

--- a/src/jupytext/cell_reader.py
+++ b/src/jupytext/cell_reader.py
@@ -747,8 +747,14 @@ class DoublePercentScriptCellReader(LightScriptCellReader):
         self.default_language = default_language or script["language"]
         self.comment = script["comment"]
         self.comment_suffix = script.get("comment_suffix", "")
-        self.start_code_re = re.compile(rf"^\s*{re.escape(self.comment)}\s*%%(%*)\s(.*)$")
-        self.alternative_start_code_re = re.compile(rf"^\s*{re.escape(self.comment)}\s*(%%|<codecell>|In\[[0-9 ]*\]:?)\s*$")
+        # Only a single optional space is allowed between the comment char and '%%':
+        # jupytext never writes more, and being permissive here makes commented-out
+        # content that merely contains '%%' (e.g. mermaid comments inside a markdown
+        # cell) look like a cell marker on the next read (#1533).
+        self.start_code_re = re.compile(rf"^\s*{re.escape(self.comment)} ?%%(%*)\s(.*)$")
+        self.alternative_start_code_re = re.compile(
+            rf"^\s*{re.escape(self.comment)} ?(%%|<codecell>|In\[[0-9 ]*\]:?)\s*$"
+        )
         self.explicit_soc = True
 
     def metadata_and_language_from_option_line(self, line):

--- a/tests/functional/simple_notebooks/test_read_simple_percent.py
+++ b/tests/functional/simple_notebooks/test_read_simple_percent.py
@@ -606,3 +606,20 @@ fmt.Printf("Hello World!")
     nb = jupytext.reads(go_percent, fmt="go:percent")
     go = jupytext.writes(nb, fmt="go:percent")
     compare(go, go_percent)
+
+
+def test_mermaid_comments_do_not_split_markdown_cell(
+    text="""# %% [markdown]
+# ```mermaid
+# stateDiagram-v2
+#     %% == States ==
+#     Idle --> Running
+# ```
+""",
+):
+    """Mermaid '%%' comments in a markdown cell are not cell markers. See issue #1533"""
+    nb = jupytext.reads(text, fmt="py:percent")
+    assert len(nb.cells) == 1
+    (cell,) = nb.cells
+    assert cell.cell_type == "markdown", cell.cell_type
+    compare(jupytext.writes(nb, fmt="py:percent"), text)

--- a/tests/functional/simple_notebooks/test_read_simple_percent.py
+++ b/tests/functional/simple_notebooks/test_read_simple_percent.py
@@ -623,3 +623,23 @@ def test_mermaid_comments_do_not_split_markdown_cell(
     (cell,) = nb.cells
     assert cell.cell_type == "markdown", cell.cell_type
     compare(jupytext.writes(nb, fmt="py:percent"), text)
+
+
+def test_mermaid_comments_at_any_indent_do_not_split_markdown_cell(
+    text="""# %% [markdown]
+# Some diagram
+#
+# ```mermaid
+# %% not indented at all
+# stateDiagram-v2
+#       %% deeply indented
+#     Idle --> Running
+# ```
+""",
+):
+    """Mermaid '%%' comments are ignored whatever their indent. See issue #1533"""
+    nb = jupytext.reads(text, fmt="py:percent")
+    assert len(nb.cells) == 1
+    (cell,) = nb.cells
+    assert cell.cell_type == "markdown", cell.cell_type
+    compare(jupytext.writes(nb, fmt="py:percent"), text)


### PR DESCRIPTION
Closes #1533

A markdown cell containing a mermaid diagram is written to `py:percent` with every line prefixed by `# `, so mermaid's `%%` comments become lines like `#     %% == States ==`. The percent reader matched the comment char followed by *arbitrary* whitespace before `%%`, so those lines were read back as new cell markers and the markdown cell was split apart.

Jupytext only ever writes a single space between the comment char and `%%`, so the reader now allows at most one. Added a round-trip regression test (fails before, passes after); the rest of the percent/round-trip suites are unchanged.
