### PR TITLE
fix: keep whitespace-only last line in percent cells

### DIFF
--- a/src/jupytext/cell_reader.py
+++ b/src/jupytext/cell_reader.py
@@ -28,6 +28,7 @@ from .pep8 import pep8_lines_between_cells
 from .stringparser import StringParser
 
 _BLANK_LINE = re.compile(r"^\s*$")
+_EMPTY_LINE = re.compile(r"^$")
 _PY_INDENTED = re.compile(r"^\s")
 
 
@@ -809,7 +810,9 @@ class DoublePercentScriptCellReader(LightScriptCellReader):
 
         if last_two_lines_blank(lines[:next_cell]):
             return next_cell - 2, next_cell, False
-        if next_cell > 0 and _BLANK_LINE.match(lines[next_cell - 1]):
+        # Only an empty line separates two cells. A line that contains
+        # whitespace is part of the cell content and must be preserved (#1599)
+        if next_cell > 0 and _EMPTY_LINE.match(lines[next_cell - 1]):
             return next_cell - 1, next_cell, False
         return next_cell, next_cell, False
 

--- a/tests/functional/simple_notebooks/test_read_simple_percent.py
+++ b/tests/functional/simple_notebooks/test_read_simple_percent.py
@@ -606,3 +606,24 @@ fmt.Printf("Hello World!")
     nb = jupytext.reads(go_percent, fmt="go:percent")
     go = jupytext.writes(nb, fmt="go:percent")
     compare(go, go_percent)
+
+
+def test_read_cell_with_trailing_whitespace_line():
+    """A last line made of spaces belongs to the cell, it is not a cell separator. See issue #1599"""
+    source = 'print("hello")\n# the following line has four spaces\n    '
+    nb = jupytext.reads("# %%\n" + source + "\n", fmt="py:percent")
+    assert len(nb.cells) == 1
+    (cell,) = nb.cells
+    compare(cell.source, source)
+
+
+def test_round_trip_cell_with_trailing_whitespace_line(no_jupytext_version_number):
+    """A cell ending with a whitespace-only line round trips. See issue #1599"""
+    source = 'print("hello")\n# the following line has four spaces\n    '
+    nb = new_notebook(
+        cells=[new_code_cell(source)],
+        metadata={"jupytext": {"main_language": "python"}},
+    )
+    text = jupytext.writes(nb, fmt="py:percent")
+    nb2 = jupytext.reads(text, fmt="py:percent")
+    compare(nb2.cells[0].source, source)


### PR DESCRIPTION
Closes #1599

In the percent format, `find_cell_end` used `_BLANK_LINE` (`^\s*$`) to detect the empty line that separates two cells, so a cell whose last line contained only spaces lost that line on read and the notebook did not round trip. Only a truly empty line is a separator, so that check now uses `_EMPTY_LINE` (`^$`).

Two regression tests were added in `tests/functional/simple_notebooks/test_read_simple_percent.py`; both fail without the one-line change and pass with it.
