### PR TITLE
run quarto convert in a private temp directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Jupytext ChangeLog
 ==================
 
+1.19.6.dev0 (2026-mm-dd)
+------------------------
+
+**Security**
+- The Quarto conversions now run in a private temporary directory, so that the output file that `quarto convert` names after its input can no longer be pre-created as a symlink by another user of the machine ([#1615](https://github.com/jupytext/jupytext/pull/1615))
+
 1.19.5 (2026-07-21)
 -------------------
 

--- a/src/jupytext/quarto.py
+++ b/src/jupytext/quarto.py
@@ -1,7 +1,6 @@
 """Jupyter notebook to Quarto Markdown and back, using 'quarto convert'"""
 
 import json
-import os
 import shutil
 import subprocess
 import sys
@@ -76,19 +75,20 @@ def quarto_version():
 def qmd_to_notebook(text):
     """Convert a Quarto Markdown notebook to a Jupyter notebook"""
     raise_if_quarto_is_not_available()
-    tmp_qmd_file = tempfile.NamedTemporaryFile(delete=False, suffix=".qmd")
-    tmp_qmd_file.write(text.encode("utf-8"))
-    tmp_qmd_file.close()
+    # Quarto derives the name of the file it writes from the name of the file it reads,
+    # so we give it a directory of its own rather than let it create that output file
+    # in the shared temporary directory
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_qmd_file = tempfile.NamedTemporaryFile(delete=False, suffix=".qmd", dir=tmp_dir)
+        tmp_qmd_file.write(text.encode("utf-8"))
+        tmp_qmd_file.close()
 
-    quarto("convert --log-level warning", tmp_qmd_file.name)
+        quarto("convert --log-level warning", tmp_qmd_file.name)
 
-    tmp_ipynb_file_name = tmp_qmd_file.name[:-4] + ".ipynb"
+        tmp_ipynb_file_name = tmp_qmd_file.name[:-4] + ".ipynb"
 
-    with open(tmp_ipynb_file_name, encoding="utf-8") as ipynb_file:
-        notebook = ipynb_reads(ipynb_file.read(), as_version=4)
-
-    os.unlink(tmp_qmd_file.name)
-    os.unlink(tmp_ipynb_file_name)
+        with open(tmp_ipynb_file_name, encoding="utf-8") as ipynb_file:
+            notebook = ipynb_reads(ipynb_file.read(), as_version=4)
 
     # Recent version of Quarto duplicate the notebook metadata in a YAML header
     # If we find such a header, we remove it if it is identical to the notebook metadata
@@ -146,18 +146,16 @@ def qmd_to_notebook(text):
 def notebook_to_qmd(notebook):
     """Convert a Jupyter notebook to its Quarto Markdown representation"""
     raise_if_quarto_is_not_available()
-    tmp_ipynb_file = tempfile.NamedTemporaryFile(delete=False, suffix=".ipynb")
-    tmp_ipynb_file.write(ipynb_writes(notebook).encode("utf-8"))
-    tmp_ipynb_file.close()
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_ipynb_file = tempfile.NamedTemporaryFile(delete=False, suffix=".ipynb", dir=tmp_dir)
+        tmp_ipynb_file.write(ipynb_writes(notebook).encode("utf-8"))
+        tmp_ipynb_file.close()
 
-    quarto("convert --log-level warning", tmp_ipynb_file.name)
+        quarto("convert --log-level warning", tmp_ipynb_file.name)
 
-    tmp_qmd_file_name = tmp_ipynb_file.name[:-6] + ".qmd"
+        tmp_qmd_file_name = tmp_ipynb_file.name[:-6] + ".qmd"
 
-    with open(tmp_qmd_file_name, encoding="utf-8") as qmd_file:
-        text = qmd_file.read()
-
-    os.unlink(tmp_ipynb_file.name)
-    os.unlink(tmp_qmd_file_name)
+        with open(tmp_qmd_file_name, encoding="utf-8") as qmd_file:
+            text = qmd_file.read()
 
     return "\n".join(text.splitlines())

--- a/src/jupytext/version.py
+++ b/src/jupytext/version.py
@@ -1,4 +1,4 @@
 """Jupytext's version number"""
 
 # Must match [N!]N(.N)*[{a|b|rc}N][.postN][.devN], cf. PEP 440
-__version__ = "1.19.5"
+__version__ = "1.19.6.dev0"

--- a/tests/unit/test_quarto_temp_files.py
+++ b/tests/unit/test_quarto_temp_files.py
@@ -1,0 +1,44 @@
+import stat
+import tempfile
+import unittest.mock as mock
+from pathlib import Path
+
+import pytest
+from nbformat import writes as ipynb_writes
+from nbformat.v4.nbbase import new_notebook
+
+from jupytext.quarto import notebook_to_qmd, qmd_to_notebook
+
+
+@pytest.fixture()
+def quarto_conversion_dirs():
+    """Patch 'quarto convert' with a stub that records where it is asked to work"""
+    dirs = []
+
+    def fake_quarto(args, filein=None):
+        if filein is None:
+            return "1.4.550\n"
+        directory = Path(filein).parent
+        dirs.append((directory, stat.S_IMODE(directory.stat().st_mode)))
+        # 'quarto convert' writes its output next to its input
+        if filein.endswith(".qmd"):
+            Path(filein[:-4] + ".ipynb").write_text(ipynb_writes(new_notebook()), encoding="utf-8")
+        else:
+            Path(filein[:-6] + ".qmd").write_text("1 + 1\n", encoding="utf-8")
+        return ""
+
+    with mock.patch("jupytext.quarto.quarto", fake_quarto):
+        yield dirs
+
+
+@pytest.mark.skip_on_windows
+@pytest.mark.parametrize("convert", [lambda: qmd_to_notebook("1 + 1\n"), lambda: notebook_to_qmd(new_notebook())])
+def test_quarto_does_not_convert_in_the_shared_temp_dir(convert, quarto_conversion_dirs):
+    """Quarto names its output after its input, so both must sit in a directory
+    that other users cannot write to"""
+    convert()
+
+    assert quarto_conversion_dirs
+    for directory, mode in quarto_conversion_dirs:
+        assert directory != Path(tempfile.gettempdir())
+        assert not mode & 0o077


### PR DESCRIPTION
`qmd_to_notebook` and `notebook_to_qmd` create their input with `NamedTemporaryFile`, then read quarto's output from a path they derive from that name by slicing off the suffix. Nothing ever creates that second path, so where `/tmp` is shared another local user can watch for the input file to appear and pre-create the sibling as a symlink before `quarto convert` writes through it. With a stub `quarto` on PATH I had a file well outside the temp directory overwritten by a single qmd conversion.

Both conversions now run inside a `TemporaryDirectory`, which `mkdtemp` creates at 0700, so the derived path is out of reach and the explicit unlinks go away with the directory. The guard belongs here rather than in the callers because it is quarto, not jupytext, that picks the output name; `pandoc.py` and `marimo.py` already hand the child only files they created themselves, so I left those alone. The changelog needed a new section, so `version.py` moves to `1.19.6.dev0` with it, as in #1578.