### PR TITLE
ignore the trusted cell option when the notebook signature is invalid

### DIFF
--- a/src/jupytext/cli.py
+++ b/src/jupytext/cli.py
@@ -542,10 +542,14 @@ def jupytext_single_file(nb_file, args, log, notary):
     config = load_jupytext_config(os.path.abspath(nb_file))
 
     def _read(path, fmt=None):
-        """Read a notebook; mark cells trusted when the signature is valid."""
+        """Read a notebook; mark the cells trusted when the signature is valid, and drop
+        the trust claims that the file makes about itself when it is not."""
         nb = read(path, fmt=fmt, config=config)
         if notary.check_signature(nb):
             notary.mark_cells(nb, True)
+        else:
+            for cell in nb.cells:
+                cell.metadata.pop("trusted", None)
         return nb
 
     def _writes(nb, fmt):

--- a/tests/functional/others/test_trust_notebook.py
+++ b/tests/functional/others/test_trust_notebook.py
@@ -305,6 +305,54 @@ async def test_notebook_remains_trusted_after_jupytext_sync(tmp_path, cm, nb_was
         )
 
 
+async def test_paired_text_file_cannot_make_a_notebook_trusted(tmp_path, cm):
+    """
+    A 'trusted' cell option in a text notebook comes from the text file itself, so it is
+    not evidence that the paired ipynb, and the outputs it holds, can be trusted
+    """
+    (tmp_path / "jupytext.toml").write_text('formats = "ipynb,py:percent"\n')
+
+    cm.root_dir = str(tmp_path)
+
+    nb = new_notebook(
+        cells=[
+            new_code_cell(
+                source="HTML('<b>hello</b>')",
+                outputs=[
+                    new_output(
+                        output_type="display_data",
+                        data={"text/html": "<b>hello</b>"},
+                        metadata={},
+                    )
+                ],
+            )
+        ],
+        metadata={
+            "kernelspec": {
+                "display_name": "Python 3",
+                "language": "python",
+                "name": "python3",
+            }
+        },
+    )
+    nb.cells[0].metadata["trusted"] = False
+
+    # Save via the CM - this also creates the paired .py file
+    await ensure_async(cm.save(dict(type="notebook", content=nb), "test.ipynb"))
+
+    nb = (await ensure_async(cm.get("test.ipynb")))["content"]
+    assert nb.cells[0].metadata["trusted"] is False
+
+    # The paired .py file is edited on disk, and it says that the cell is trusted
+    py_file = tmp_path / "test.py"
+    py_file.write_text(py_file.read_text().replace("# %%\n", "# %% trusted=true\n"))
+
+    jupytext_cli(["--sync", str(tmp_path / "test.ipynb")], notary=cm.notary)
+
+    nb = (await ensure_async(cm.get("test.ipynb")))["content"]
+    assert nb.cells[0].metadata["trusted"] is False, "The .py file should not have made the notebook trusted"
+
+
 @pytest.mark.requires_myst
 async def test_paired_notebook_with_outputs_is_not_trusted_941(tmp_path, python_notebook, cm):
     cm.root_dir = str(tmp_path)


### PR DESCRIPTION
Signature check on a paired `.ipynb` before and after a sync, where the `.py` half was hand-written with a `trusted=true` cell option:

    >>> notary.check_signature(nbformat.read('evil.ipynb', as_version=4))
    False
    $ jupytext --sync evil.py
    [jupytext] Loading evil.ipynb
    [jupytext] Unchanged evil.ipynb
    >>> notary.check_signature(nbformat.read('evil.ipynb', as_version=4))
    True

`_read` marks cells only on the valid-signature branch, so a `trusted` option that came from the text file is still there when `_writes` calls `check_cells`, and the notebook gets signed along with whatever rich outputs the `.ipynb` holds. Jupyter Server's `mark_trusted_cells` passes the boolean both ways for this reason. An `.ipynb` cannot smuggle the flag in, since `strip_transient` drops it on read and write, but a text notebook is parsed here so it can.

I cleared the key instead of marking `trusted=False`, which is the same decision for `_check_cell` and keeps `--test-strict` round trips unchanged.
