### PR TITLE
escape cell markers and endofcell before compiling them

### DIFF
--- a/src/jupytext/cell_reader.py
+++ b/src/jupytext/cell_reader.py
@@ -605,8 +605,10 @@ class LightScriptCellReader(ScriptCellReader):
         self.explicit_end_marker_required = False
         if fmt and fmt.get("format_name", "light") == "light" and "cell_markers" in fmt and fmt["cell_markers"] != "+,-":
             self.cell_marker_start, self.cell_marker_end = fmt["cell_markers"].split(",", 1)
-            self.start_code_re = re.compile("^" + re.escape(self.comment) + r"\s*" + self.cell_marker_start + r"(.*)$")
-            self.end_code_re = re.compile("^" + re.escape(self.comment) + r"\s*" + self.cell_marker_end + r"\s*$")
+            self.start_code_re = re.compile(
+                "^" + re.escape(self.comment) + r"\s*" + re.escape(self.cell_marker_start) + r"(.*)$"
+            )
+            self.end_code_re = re.compile("^" + re.escape(self.comment) + r"\s*" + re.escape(self.cell_marker_end) + r"\s*$")
         else:
             self.start_code_re = re.compile("^" + re.escape(self.comment) + r"\s*\+(.*)$")
 
@@ -681,7 +683,7 @@ class LightScriptCellReader(ScriptCellReader):
             self.end_code_re = None
         elif not self.cell_marker_end:
             end_of_cell = self.metadata.get("endofcell", "-")
-            self.end_code_re = re.compile("^" + re.escape(self.comment) + " " + end_of_cell + r"\s*$")
+            self.end_code_re = re.compile("^" + re.escape(self.comment) + " " + re.escape(end_of_cell) + r"\s*$")
 
         return self.find_region_end(lines)
 

--- a/src/jupytext/cell_to_text.py
+++ b/src/jupytext/cell_to_text.py
@@ -369,8 +369,10 @@ class LightScriptCellExporter(BaseCellExporter):
         if self.metadata:
             return True
         if self.cell_marker_start:
-            start_code_re = re.compile("^" + self.comment + r"\s*" + self.cell_marker_start + r"\s*(.*)$")
-            end_code_re = re.compile("^" + self.comment + r"\s*" + self.cell_marker_end + r"\s*$")
+            start_code_re = re.compile(
+                "^" + re.escape(self.comment) + r"\s*" + re.escape(self.cell_marker_start) + r"\s*(.*)$"
+            )
+            end_code_re = re.compile("^" + re.escape(self.comment) + r"\s*" + re.escape(self.cell_marker_end) + r"\s*$")
             if start_code_re.match(source[0]) or end_code_re.match(source[0]):
                 return False
 

--- a/tests/functional/others/test_cell_markers.py
+++ b/tests/functional/others/test_cell_markers.py
@@ -1,4 +1,6 @@
-from nbformat.v4.nbbase import new_raw_cell
+import time
+
+from nbformat.v4.nbbase import new_code_cell, new_notebook, new_raw_cell
 
 from jupytext import reads, writes
 from jupytext.cli import jupytext
@@ -31,3 +33,62 @@ A raw cell
 """
 '''
     )
+
+
+def test_endofcell_option_is_matched_literally():
+    """The endofcell option is read from the text file, so '# aa' below is not an end of cell marker"""
+    py = '# + endofcell="a+"\n1 + 1\n\n# aa\n\n2 + 2\n'
+
+    nb = reads(py, fmt="py:light")
+
+    assert len(nb.cells) == 1
+
+
+def test_endofcell_option_does_not_backtrack():
+    py = '# + endofcell="(a+)+b"\n1 + 1\n\n# ' + "a" * 28 + "X\n"
+
+    start = time.perf_counter()
+    reads(py, fmt="py:light")
+    assert time.perf_counter() - start < 2
+
+
+def test_cell_markers_are_matched_literally(
+    no_jupytext_version_number,
+    py="""# ---
+# jupyter:
+#   jupytext:
+#     cell_markers: a+,b+
+#     text_representation:
+#       extension: .py
+#       format_name: light
+# ---
+
+# aa
+1 + 1
+""",
+):
+    nb = reads(py, fmt="py")
+
+    assert len(nb.cells) == 1
+    assert nb.cells[0].source == "# aa\n1 + 1"
+
+
+def test_cell_markers_do_not_backtrack_when_writing():
+    nb = new_notebook(
+        cells=[new_code_cell("#" + "a" * 28 + "X\n\npass")],
+        metadata={"jupytext": {"cell_markers": "(a+)+b,(a+)+b", "main_language": "python"}},
+    )
+
+    start = time.perf_counter()
+    writes(nb, fmt="py:light")
+    assert time.perf_counter() - start < 2
+
+
+def test_cell_markers_with_block_comment_language():
+    """The OCaml comment '(*' is not a regular expression either"""
+    nb = new_notebook(
+        cells=[new_code_cell("(* a comment *)\n\nlet x = 1")],
+        metadata={"jupytext": {"cell_markers": "region,endregion", "main_language": "ocaml"}},
+    )
+
+    assert "let x = 1" in writes(nb, fmt="ml:light")


### PR DESCRIPTION
    >>> py = '# + endofcell="(a+)+b"\n1 + 1\n\n# ' + 'a' * 28 + 'X\n'
    >>> timeit(lambda: jupytext.reads(py, fmt='py:light'), number=1)
    6.005      # 24 a's: 0.36s, 26 a's: 1.45s, 30 a's: 24s

    >>> jupytext.reads('# + endofcell="["\n1 + 1\n\n# -\n', fmt='py:light')
    re.error: unterminated character set at position 4

`endofcell` and `cell_markers` are read from the file being converted, then spliced into a regex with no `re.escape`, so the file gets to choose the pattern. `cell_markers` does the same on the write side, through the jupytext metadata of the notebook. The matching missing escape on `self.comment` in `explicit_start_marker` makes `writes(nb, fmt='ml:light')` raise `nothing to repeat` once cell markers are set, OCaml's comment being `(*`.

`guess_format` already escapes the comment string; this does the same at the four remaining sites. `region,endregion`, `{{{,}}}` and `-` are literals, so escaping leaves them matching what they matched before.
