### PR TITLE
Fix file type label in context menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Jupytext ChangeLog
 ==================
 
-1.19.6 (2026-mm-dd)
+1.19.6.dev0 (development)
 ------------------------
 
 **Fixed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Jupytext ChangeLog
 ==================
 
 1.19.6.dev0 (development)
-------------------------
+-------------------------
 
 **Fixed**
 - Menu entries such as "Rename Notebook…" name the file type again, instead of saying "default" ([#1632](https://github.com/jupytext/jupytext/pull/1632))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Jupytext ChangeLog
 ==================
 
+1.19.6 (2026-mm-dd)
+------------------------
+
+**Fixed**
+- Menu entries such as "Rename Notebook…" name the file type again, instead of saying "default" ([#1632](https://github.com/jupytext/jupytext/pull/1632))
+
 1.19.5 (2026-07-21)
 -------------------
 

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/index.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/index.ts
@@ -54,7 +54,6 @@ import {
   CommandIDs,
   IFileTypeData,
   JupytextIcon,
-  AUTO_LANGUAGE_FILETYPE_DATA,
 } from './tokens';
 
 import {
@@ -379,15 +378,7 @@ const extension: JupyterFrontEndPlugin<void> = {
       );
 
     // Register Jupytext text notebooks file types
-    registerFileTypes(
-      availableKernelLanguages,
-      [
-        ...[...JUPYTEXT_PAIR_COMMANDS_FILETYPE_DATA.values()].flat(),
-        ...[...AUTO_LANGUAGE_FILETYPE_DATA.values()].flat(),
-      ],
-      docRegistry,
-      trans,
-    );
+    registerFileTypes(availableKernelLanguages, docRegistry, trans);
 
     // Get all kernel file types to add to Jupytext factory
     const kernelLanguageNames: string[] = [];

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/registry.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/registry.ts
@@ -4,54 +4,32 @@ import { TranslationBundle } from '@jupyterlab/translation';
 
 import { markdownIcon, LabIcon, fileIcon } from '@jupyterlab/ui-components';
 
+import { IDisposable } from '@lumino/disposable';
+
 import { IFileTypeData } from './tokens';
+
+/**
+ * Return the source of a regular expression matching `text`, whatever the case
+ * of its letters. JupyterLab compares extensions in a case-insensitive way, but
+ * matches `pattern` as it is written.
+ */
+function caseInsensitiveSource(text: string): string {
+  return text
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    .replace(
+      /[a-zA-Z]/g,
+      (letter) => `[${letter.toLowerCase()}${letter.toUpperCase()}]`,
+    );
+}
 
 export function registerFileTypes(
   availableKernelLanguages: Map<string, IFileTypeData[]>,
-  jupytextFormatsWithFileTypeData: IFileTypeData[],
   docRegistry: DocumentRegistry,
   trans: TranslationBundle,
 ) {
   const mystExtensions = ['myst', 'mystnb', 'mnb'];
   const rmdExtensions = ['Rmd'];
   const quartoExtensions = ['qmd'];
-
-  const extensionsWithFactory = [
-    ...mystExtensions,
-    ...rmdExtensions,
-    ...quartoExtensions,
-  ];
-
-  // Add a catch-all file type to overrride icon which by default is derive from model type.
-  // Because jupytext changes the type of all files it can handle to Notebook, we need to
-  // override it. We exclude file types which have dedicated icons (handled later).
-  const excludedExtensions = [
-    'ipynb',
-    ...jupytextFormatsWithFileTypeData.map((f) => f.fileExt),
-    ...extensionsWithFactory,
-  ].join('|');
-  docRegistry.addFileType({
-    name: 'jupytext-notebook-file',
-    contentType: 'notebook',
-    pattern: `^(?!.*\\.(${excludedExtensions})$).*$`,
-    icon: fileIcon,
-  });
-
-  // Handle file types with dedicated icons
-  for (const format of jupytextFormatsWithFileTypeData) {
-    if (!extensionsWithFactory.includes(format.fileExt)) {
-      docRegistry.addFileType({
-        name: `${format.fileExt}-jupytext-notebook`,
-        contentType: 'notebook',
-        // `pattern` field gives it precedence over other file type information when resolving the icon
-        pattern: `\\.${format.fileExt}$`,
-        extensions: [`.${format.fileExt}`],
-        icon: format.iconName
-          ? LabIcon.resolve({ icon: format.iconName })
-          : format.kernelIcon,
-      });
-    }
-  }
 
   // Add kernel file types to registry
   availableKernelLanguages.forEach(
@@ -60,7 +38,6 @@ export function registerFileTypes(
         docRegistry.addFileType({
           name: kernelLanguage,
           contentType: 'notebook',
-          pattern: `\\.${kernelFileType.fileExt}$`,
           displayName: trans.__(
             kernelFileType.paletteLabel.split('New')[1].trim(),
           ),
@@ -109,9 +86,78 @@ export function registerFileTypes(
       contentType: 'notebook',
       displayName: trans.__('Quarto Notebook'),
       extensions: quartoExtensions.map((ext) => '.' + ext),
-      pattern: '\\.qmd$',
       icon: markdownNotebookIcon,
     },
     ['Notebook'],
   );
+
+  // Jupytext's contents manager gives the `notebook` type to every file it can
+  // open, and JupyterLab resolves the icon of such a file from the file types
+  // which declare the `notebook` content type, falling back to the notebook
+  // file type when none of them matches (#398). Copy the file types which can
+  // describe a text notebook, and cover the extensions which none of them
+  // describes with a catch-all. The copies match on their extensions rather
+  // than on a `pattern`, because a `pattern` takes precedence over the file
+  // type it copies, and would also take over the name that JupyterLab shows in
+  // menu entries such as "Rename Notebook…" (#1629).
+  const knownExtensions = new Set<string>();
+  const copiedFileTypes = new Set<string>();
+  let catchAllFileType: IDisposable | null = null;
+
+  const addNotebookFileTypes = () => {
+    let isCatchAllStale = false;
+    for (const fileType of [...docRegistry.fileTypes()]) {
+      if (!fileType.extensions.length) {
+        continue;
+      }
+      if (fileType.extensions.some((ext) => !knownExtensions.has(ext))) {
+        fileType.extensions.forEach((ext) => knownExtensions.add(ext));
+        isCatchAllStale = true;
+      }
+      // Notebooks and directories already resolve correctly, and files stored
+      // as base64 (images, audio, video) are never text notebooks.
+      if (
+        fileType.contentType !== 'file' ||
+        fileType.fileFormat === 'base64' ||
+        copiedFileTypes.has(fileType.name)
+      ) {
+        continue;
+      }
+      copiedFileTypes.add(fileType.name);
+      docRegistry.addFileType({
+        name: `${fileType.name}-jupytext-notebook`,
+        contentType: 'notebook',
+        displayName: fileType.displayName,
+        extensions: fileType.extensions,
+        fileFormat: fileType.fileFormat,
+        icon: fileType.icon,
+        iconClass: fileType.iconClass,
+        iconLabel: fileType.iconLabel,
+      });
+      isCatchAllStale = true;
+    }
+    if (!isCatchAllStale) {
+      return;
+    }
+    const knownEnding = [...knownExtensions]
+      .map(caseInsensitiveSource)
+      .join('|');
+    catchAllFileType?.dispose();
+    catchAllFileType = docRegistry.addFileType({
+      name: 'jupytext-notebook-file',
+      contentType: 'notebook',
+      displayName: trans.__('File'),
+      pattern: `^(?!.*(${knownEnding})$).*$`,
+      icon: fileIcon,
+    });
+  };
+
+  addNotebookFileTypes();
+
+  // Extensions activated after Jupytext register their file types later
+  docRegistry.changed.connect((_, change) => {
+    if (change.type === 'fileType' && change.change === 'added') {
+      addNotebookFileTypes();
+    }
+  });
 }

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/ui-tests/tests/jupytext-file-types.spec.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/ui-tests/tests/jupytext-file-types.spec.ts
@@ -1,0 +1,71 @@
+import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
+
+const notebookName = 'file-types.ipynb';
+const scriptName = 'file-types.py';
+const textFileName = 'file-types.txt';
+
+/**
+ * Open the context menu of a tab of the main area and return the labels of
+ * its items.
+ */
+async function getTabContextMenuLabels(
+  page: IJupyterLabPageFixture,
+  tabName: string,
+): Promise<string[]> {
+  await page.activity.getTabLocator(tabName).click({ button: 'right' });
+  const menu = page.locator('.lm-Menu').last();
+  await expect(menu).toBeVisible();
+  const labels = await menu.locator('.lm-Menu-itemLabel').allInnerTexts();
+  await page.keyboard.press('Escape');
+  return labels;
+}
+
+test.describe('Jupytext File Type Tests', () => {
+  test('Notebook commands are named after the notebook file type', async ({
+    page,
+  }) => {
+    await page.notebook.createNew(notebookName, { kernel: 'python3' });
+
+    const labels = await getTabContextMenuLabels(page, notebookName);
+
+    expect(labels).toContain('Rename Notebook…');
+    expect(labels.filter((label) => label.includes('default'))).toEqual([]);
+  });
+
+  test('Text file commands are not named after the default file type', async ({
+    page,
+    tmpPath,
+  }) => {
+    await page.contents.uploadContent(
+      'Some text\n',
+      'text',
+      `${tmpPath}/${textFileName}`,
+    );
+    await page.filebrowser.refresh();
+    await page.filebrowser.open(textFileName);
+
+    const labels = await getTabContextMenuLabels(page, textFileName);
+
+    expect(labels.filter((label) => label.includes('default'))).toEqual([]);
+  });
+
+  test('Scripts keep the icon of their language in the file browser', async ({
+    page,
+    tmpPath,
+  }) => {
+    await page.contents.uploadContent(
+      '1 + 1\n',
+      'text',
+      `${tmpPath}/${scriptName}`,
+    );
+    await page.filebrowser.refresh();
+
+    const item = page
+      .getByRole('region', { name: 'File Browser Section' })
+      .getByRole('listitem', { name: new RegExp(`^Name: ${scriptName}`) });
+
+    await expect(
+      item.locator('.jp-DirListing-itemIcon [data-icon]'),
+    ).toHaveAttribute('data-icon', 'ui-components:python');
+  });
+});

--- a/jupyterlab/scripts/install_extension.py
+++ b/jupyterlab/scripts/install_extension.py
@@ -12,7 +12,7 @@
 import os
 
 import jupyterlab_jupytext
-from jupyter_builder.federated_labextensions import build_labextension, develop_labextension
+from jupyter_builder.federated_extensions import build_labextension, develop_labextension
 
 
 def main():

--- a/src/jupytext/version.py
+++ b/src/jupytext/version.py
@@ -1,4 +1,4 @@
 """Jupytext's version number"""
 
 # Must match [N!]N(.N)*[{a|b|rc}N][.postN][.devN], cf. PEP 440
-__version__ = "1.19.5"
+__version__ = "1.19.6.dev0"


### PR DESCRIPTION
- [x] Fixes `install_extension.py` script broken after #1590
- [x] Adds a test for file type registration (should fail in the initial commit)
- [x] Fixes #1629
- [x] Updates changelog


| Before | After |
|--|--|
| <img width="506" height="369" alt="image" src="https://github.com/user-attachments/assets/e0de2f67-f5c6-466c-9930-ba437cbb3b22" /> | <img width="506" height="369" alt="image" src="https://github.com/user-attachments/assets/e5eb60a7-9b5e-4fc5-86fd-d0256dde24c8" /> |
